### PR TITLE
-Fixed Forsaken Summoned Unit Classifications

### DIFF
--- a/UnitData.slk
+++ b/UnitData.slk
@@ -16820,7 +16820,7 @@ C;X15;K1
 C;X16;K60
 C;X17;K0
 C;X18;K2
-C;X19;K"structure"
+C;X19;K"ground"
 C;X20;K"_"
 C;X21;K0
 C;X22;K0
@@ -16851,7 +16851,7 @@ C;X15;K1
 C;X16;K60
 C;X17;K0
 C;X18;K2
-C;X19;K"structure"
+C;X19;K"ground"
 C;X20;K"_"
 C;X21;K0
 C;X22;K0
@@ -16882,7 +16882,7 @@ C;X15;K1
 C;X16;K60
 C;X17;K0
 C;X18;K2
-C;X19;K"structure"
+C;X19;K"ground"
 C;X20;K"_"
 C;X21;K0
 C;X22;K0
@@ -16913,7 +16913,7 @@ C;X15;K1
 C;X16;K60
 C;X17;K0
 C;X18;K2
-C;X19;K"structure"
+C;X19;K"ground"
 C;X20;K"_"
 C;X21;K0
 C;X22;K0
@@ -16944,7 +16944,7 @@ C;X15;K1
 C;X16;K60
 C;X17;K0
 C;X18;K2
-C;X19;K"structure"
+C;X19;K"ground"
 C;X20;K"_"
 C;X21;K0
 C;X22;K0
@@ -16975,7 +16975,7 @@ C;X15;K1
 C;X16;K60
 C;X17;K0
 C;X18;K2
-C;X19;K"structure"
+C;X19;K"ground"
 C;X20;K"_"
 C;X21;K0
 C;X22;K0


### PR DESCRIPTION
Units were classified as structures; need to be ground.